### PR TITLE
Provides option to attach a custom IAM role to the Node Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Available targets:
 | <a name="input_module_depends_on"></a> [module\_depends\_on](#input\_module\_depends\_on) | Can be any value desired. Module will wait for this value to be computed before creating node group. | `any` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
+| <a name="input_node_role_arn"></a> [node\_role\_arn](#input\_node\_role\_arn) | If provided, assign workers the given role, which this module will not modify | `list(string)` | `[]` | no |
 | <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | If provided, all IAM roles will be created with this permissions boundary attached. | `string` | `null` | no |
 | <a name="input_regex_replace_chars"></a> [regex\_replace\_chars](#input\_regex\_replace\_chars) | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | <a name="input_remote_access_enabled"></a> [remote\_access\_enabled](#input\_remote\_access\_enabled) | Whether to enable remote access to EKS node group, requires `ec2_ssh_key` to be defined. | `bool` | `false` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -1,13 +1,14 @@
 locals {
+  create_role       = local.enabled && length(var.node_role_arn) == 0
   aws_policy_prefix = format("arn:%s:iam::aws:policy", join("", data.aws_partition.current.*.partition))
 }
 
 data "aws_partition" "current" {
-  count = local.enabled ? 1 : 0
+  count = local.create_role ? 1 : 0
 }
 
 data "aws_iam_policy_document" "assume_role" {
-  count = local.enabled ? 1 : 0
+  count = local.create_role ? 1 : 0
 
   statement {
     effect  = "Allow"
@@ -21,7 +22,7 @@ data "aws_iam_policy_document" "assume_role" {
 }
 
 data "aws_iam_policy_document" "amazon_eks_worker_node_autoscale_policy" {
-  count = (local.enabled && var.worker_role_autoscale_iam_enabled) ? 1 : 0
+  count = (local.create_role && var.worker_role_autoscale_iam_enabled) ? 1 : 0
   statement {
     sid = "AllowToScaleEKSNodeGroupAutoScalingGroup"
 
@@ -42,13 +43,13 @@ data "aws_iam_policy_document" "amazon_eks_worker_node_autoscale_policy" {
 }
 
 resource "aws_iam_policy" "amazon_eks_worker_node_autoscale_policy" {
-  count  = (local.enabled && var.worker_role_autoscale_iam_enabled) ? 1 : 0
+  count  = (local.create_role && var.worker_role_autoscale_iam_enabled) ? 1 : 0
   name   = "${module.label.id}-autoscale"
   policy = join("", data.aws_iam_policy_document.amazon_eks_worker_node_autoscale_policy.*.json)
 }
 
 resource "aws_iam_role" "default" {
-  count                = local.enabled ? 1 : 0
+  count                = local.create_role ? 1 : 0
   name                 = module.label.id
   assume_role_policy   = join("", data.aws_iam_policy_document.assume_role.*.json)
   permissions_boundary = var.permissions_boundary
@@ -56,31 +57,31 @@ resource "aws_iam_role" "default" {
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_policy" {
-  count      = local.enabled ? 1 : 0
+  count      = local.create_role ? 1 : 0
   policy_arn = format("%s/%s", local.aws_policy_prefix, "AmazonEKSWorkerNodePolicy")
   role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_worker_node_autoscale_policy" {
-  count      = (local.enabled && var.worker_role_autoscale_iam_enabled) ? 1 : 0
+  count      = (local.create_role && var.worker_role_autoscale_iam_enabled) ? 1 : 0
   policy_arn = join("", aws_iam_policy.amazon_eks_worker_node_autoscale_policy.*.arn)
   role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_eks_cni_policy" {
-  count      = local.enabled ? 1 : 0
+  count      = local.create_role ? 1 : 0
   policy_arn = format("%s/%s", local.aws_policy_prefix, "AmazonEKS_CNI_Policy")
   role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "amazon_ec2_container_registry_read_only" {
-  count      = local.enabled ? 1 : 0
+  count      = local.create_role ? 1 : 0
   policy_arn = format("%s/%s", local.aws_policy_prefix, "AmazonEC2ContainerRegistryReadOnly")
   role       = join("", aws_iam_role.default.*.name)
 }
 
 resource "aws_iam_role_policy_attachment" "existing_policies_for_eks_workers_role" {
-  for_each   = local.enabled ? toset(var.existing_workers_role_policy_arns) : []
+  for_each   = local.create_role ? toset(var.existing_workers_role_policy_arns) : []
   policy_arn = each.value
   role       = join("", aws_iam_role.default.*.name)
 }

--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ locals {
   ng_needs_remote_access = local.remote_access_enabled && ! local.use_launch_template
   ng = {
     cluster_name  = var.cluster_name
-    node_role_arn = join("", aws_iam_role.default.*.arn)
+    node_role_arn = local.create_role ? join("", aws_iam_role.default.*.arn) : var.node_role_arn[0]
     # Keep sorted so that change in order does not trigger replacement via random_pet
     subnet_ids = sort(var.subnet_ids)
     disk_size  = local.use_launch_template ? null : var.disk_size

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,18 @@ variable "subnet_ids" {
   type        = list(string)
 }
 
+variable "node_role_arn" {
+  type        = list(string)
+  default     = []
+  description = "If provided, assign workers the given role, which this module will not modify"
+  validation {
+    condition = (
+      length(var.node_role_arn) < 2
+    )
+    error_message = "You may not specify more than one `node_role_arn`."
+  }
+}
+
 variable "security_group_description" {
   type        = string
   default     = "Allow SSH access to all nodes in the nodeGroup"


### PR DESCRIPTION
As [AWS announced](https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/), the IAM roles that assume themselves need to have an explicit trust statement to be able to do so.
Before, this was implicitly allowed.

For this reason (but not only), we want to be able to pass a custom IAM role, when the need arises.